### PR TITLE
The feed index

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,7 @@ model Event {
   favorite      Boolean?
   tag           String?
   date          DateTime?
+  likedIds      String[] @db.ObjectId
 
   sharedUserIds String[] @db.ObjectId
   sharedUsers   User[]   @relation(name: "sharedEvents", fields: [sharedUserIds], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,11 +47,13 @@ model User {
   image          String?
   hashedPassword String?
   sharedEventIds String[]  @db.ObjectId
+  likedEventIds String[]  @db.ObjectId
 
   accounts        Account[]
   sessions        Session[]
   initiatedEvents Event[]   @relation(name: "initiatedEvents")
   sharedEvents    Event[]   @relation(name: "sharedEvents", fields: [sharedEventIds], references: [id])
+  likedEvents     Event[]   @relation(name: "likedEvents", fields: [likedEventIds], references: [id])
   notes           Note[]
 }
 
@@ -65,7 +67,9 @@ model Event {
   favorite      Boolean?
   tag           String?
   date          DateTime?
-  likedIds      String[] @db.ObjectId
+
+  likedUserIds  String[] @db.ObjectId
+  linkedUsers   User[] @relation(name: "likedEvents", fields: [likedUserIds], references: [id])
 
   sharedUserIds String[] @db.ObjectId
   sharedUsers   User[]   @relation(name: "sharedEvents", fields: [sharedUserIds], references: [id])

--- a/public/thumbnail-placeholder.svg
+++ b/public/thumbnail-placeholder.svg
@@ -1,0 +1,10 @@
+<svg width="92" height="92" viewBox="0 0 92 92" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_155_81)">
+<rect width="92" height="92" rx="5" fill="#FDA6A6"/>
+</g>
+<defs>
+<clipPath id="clip0_155_81">
+<rect width="92" height="92" rx="5" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -54,11 +54,10 @@ const BottomNav: FC<NavTabProps> = ({
             key={nav.tabName}
             href={nav.href}
             className={`flex flex-col items-center px-3 transition duration-500 hover:scale-110" mr-1
-            ${
-              checkCurrentRoute(nav.href)
+            ${checkCurrentRoute(nav.href)
                 ? ''
                 : 'text-gray-800 dark:text-gray-500 text-opacity-50'
-            }`}
+              }`}
           >
             {nav.icon}
             {/* <span className="mt-1 text-xs dark:text-gray-500">Home</span> */}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -9,7 +9,7 @@ import { Typography } from './ui/Typography';
 interface EventCardProps {
     thumbnail?: string,
     eventName: string,
-    eventDescription: string,
+    eventDescription?: string,
     isFavorite: boolean
 }
 

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,12 +1,17 @@
-
 import { FC } from 'react'
+import axios from 'axios'
+import { useRouter } from 'next/router';
 
 import { AiFillHeart, AiOutlineHeart } from 'react-icons/ai';
 import Image from 'next/image'
 
+import useEvents from '@/hooks/useEvents';
+import { useToast } from '@/hooks/useToast'
+
 import { Typography } from './ui/Typography';
 
 interface EventCardProps {
+    eventId: string,
     thumbnail?: string,
     eventName: string,
     eventDescription?: string,
@@ -14,20 +19,56 @@ interface EventCardProps {
 }
 
 const EventCard: FC<EventCardProps> = ({
+    eventId,
     thumbnail,
     eventName,
     eventDescription,
     isFavorite
 }) => {
+    const { mutate: mutateEvents } = useEvents()
+    const { toast } = useToast()
+    const router = useRouter();
+
+    const toggleFavorite = async () => {
+        try {
+
+            await axios.patch(`/api/events/${eventId}`, {
+                title: eventName,
+                brochure_img: thumbnail,
+                favorite: !isFavorite
+            })
+
+            toast({
+                variant: 'success',
+                description: !isFavorite ? 'Set the event to the favorite list' : 'Remove the event from the favorite list.',
+            })
+
+            mutateEvents()
+            window.location.reload()
+        } catch (error) {
+            toast({
+                variant: 'destructive',
+                description: 'Something went wrong',
+            })
+        } finally {
+            window.location.reload()
+        }
+    }
+
+    const navigateToEventPage = () => {
+        router.push(`/events/${eventId}`)
+    }
 
     return (
-        <div className='flex p-2 mb-4 bg-white border rounded shadow-md border-slate-100'>
-            <Image src={thumbnail || '/thumbnail-placeholder.svg'} width={92} height={92} alt={eventName} />
-            <div className='ml-4 text-left'>
+        <div onClick={navigateToEventPage} className='flex p-2 mb-4 bg-white border rounded shadow-md border-slate-100'>
+            <div className='rounded'>
+                <Image src={thumbnail || '/thumbnail-placeholder.svg'} width={92} height={92} alt={eventName} />
+            </div>
+            <div className='w-7/12 ml-4 text-left'>
                 <Typography variant="subhead2" children={eventName} />
                 <Typography variant="bodytext1" children={eventDescription} />
             </div>
-            <div>
+            <div onClick={toggleFavorite}>
                 {isFavorite ? <AiFillHeart /> : <AiOutlineHeart />}
             </div>
         </div>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,37 @@
+
+import { FC } from 'react'
+
+import { AiFillHeart, AiOutlineHeart } from 'react-icons/ai';
+import Image from 'next/image'
+
+import { Typography } from './ui/Typography';
+
+interface EventCardProps {
+    thumbnail?: string,
+    eventName: string,
+    eventDescription: string,
+    isFavorite: boolean
+}
+
+const EventCard: FC<EventCardProps> = ({
+    thumbnail,
+    eventName,
+    eventDescription,
+    isFavorite
+}) => {
+
+    return (
+        <div className='flex p-2 bg-white border rounded shadow-md border-slate-100'>
+            <Image src={thumbnail || '/thumbnail-placeholder.svg'} width={92} height={92} alt={eventName} />
+            <div className='ml-4 text-left'>
+                <Typography variant="subhead2" children={eventName} />
+                <Typography variant="bodytext1" children={eventDescription} />
+            </div>
+            <div>
+                {isFavorite ? <AiFillHeart /> : <AiOutlineHeart />}
+            </div>
+        </div>
+    )
+}
+
+export default EventCard;

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -21,7 +21,7 @@ const EventCard: FC<EventCardProps> = ({
 }) => {
 
     return (
-        <div className='flex p-2 bg-white border rounded shadow-md border-slate-100'>
+        <div className='flex p-2 mb-4 bg-white border rounded shadow-md border-slate-100'>
             <Image src={thumbnail || '/thumbnail-placeholder.svg'} width={92} height={92} alt={eventName} />
             <div className='ml-4 text-left'>
                 <Typography variant="subhead2" children={eventName} />

--- a/src/components/FeedIndex.tsx
+++ b/src/components/FeedIndex.tsx
@@ -1,48 +1,68 @@
 import { AiOutlineHeart, AiOutlineSmile } from 'react-icons/ai'
 import { MdFlipCameraAndroid } from 'react-icons/md'
 
-import useEvents from '@/hooks/useEvents';
-import { useSession } from 'next-auth/react';
-import { Event } from '@/lib/schema';
+import useEvents from '@/hooks/useEvents'
+import { useSession } from 'next-auth/react'
+import { Event } from '@/lib/schema'
 
-import BottomNav from '@/components/BottomNav';
-import EventCard from '@/components/EventCard';
+import BottomNav from '@/components/BottomNav'
+import EventCard from '@/components/EventCard'
 
 const navList = [
-    {
-        name: 'Favorite',
-        href: '/',
-        tabName: 'Favorite',
-        icon: <AiOutlineHeart size={24} />,
-    },
-    {
-        name: 'Capture',
-        href: '/capture',
-        tabName: 'Capture',
-        icon: <MdFlipCameraAndroid size={24} />,
-    },
-    {
-        name: 'Profile',
-        href: '/profile',
-        tabName: 'Profile',
-        icon: <AiOutlineSmile size={24} />,
-    },
+  {
+    name: 'Favorite',
+    href: '/',
+    tabName: 'Favorite',
+    icon: <AiOutlineHeart size={24} />,
+  },
+  {
+    name: 'Capture',
+    href: '/capture',
+    tabName: 'Capture',
+    icon: <MdFlipCameraAndroid size={24} />,
+  },
+  {
+    name: 'Profile',
+    href: '/profile',
+    tabName: 'Profile',
+    icon: <AiOutlineSmile size={24} />,
+  },
 ]
 
-export function FeedIndex() {
-    const { data: session } = useSession()
-    const { data: events } = useEvents(session?.user.id);
 
-    return (
-        <>
-            <div className='w-full px-4'>
-                {
-                    events && events.map(({ id, brochure_img, favorite, notes, title }: Event) => {
-                        return <EventCard key={id} eventId={id} eventName={title} eventDescription={notes?.join('')} thumbnail={brochure_img} isFavorite={Boolean(favorite)} />
-                    })
-                }
-            </div>
-            <BottomNav tabs={navList} />
-        </>
-    )
+interface FeedIndexProps {
+  userId?: string
 }
+
+const FeedIndex: React.FC<FeedIndexProps> = ({ userId }) => {
+  const { data: session } = useSession()
+  const { data: events } = useEvents(session?.user.id)
+
+  console.log(events)
+
+  return (
+    <>
+      <div className="w-full px-4 pb-24">
+        <h1>ff</h1>
+        {events &&
+          events.map(({ id, brochure_img, favorite, notes, title, likedIds }: Event) => {
+            return (
+              <EventCard
+                key={id}
+                userId={userId}
+                eventId={id}
+                likes={likedIds.length}
+                eventName={title}
+                eventDescription={notes?.join('')}
+                thumbnail={brochure_img}
+                isFavorite={Boolean(favorite)}
+              />
+            )
+          })}
+      </div>
+      <BottomNav tabs={navList} />
+    </>
+  )
+}
+
+export default FeedIndex;

--- a/src/components/FeedIndex.tsx
+++ b/src/components/FeedIndex.tsx
@@ -3,6 +3,7 @@ import { MdFlipCameraAndroid } from 'react-icons/md'
 
 import useEvents from '@/hooks/useEvents';
 import { useSession } from 'next-auth/react';
+import { Event } from '@/lib/schema';
 
 import BottomNav from '@/components/BottomNav';
 import EventCard from '@/components/EventCard';
@@ -36,8 +37,8 @@ export function FeedIndex() {
         <>
             <div className='w-full px-4'>
                 {
-                    events && events.map(({ brochure_img, favorite, note, title }) => {
-                        return <EventCard eventName={title} eventDescription={note} thumbnail={brochure_img} isFavorite={favorite} />
+                    events && events.map(({ brochure_img, favorite, notes, title }: Event) => {
+                        return <EventCard eventName={title} eventDescription={notes?.join('')} thumbnail={brochure_img} isFavorite={Boolean(favorite)} />
                     })
                 }
             </div>

--- a/src/components/FeedIndex.tsx
+++ b/src/components/FeedIndex.tsx
@@ -37,8 +37,8 @@ export function FeedIndex() {
         <>
             <div className='w-full px-4'>
                 {
-                    events && events.map(({ brochure_img, favorite, notes, title }: Event) => {
-                        return <EventCard eventName={title} eventDescription={notes?.join('')} thumbnail={brochure_img} isFavorite={Boolean(favorite)} />
+                    events && events.map(({ id, brochure_img, favorite, notes, title }: Event) => {
+                        return <EventCard key={id} eventId={id} eventName={title} eventDescription={notes?.join('')} thumbnail={brochure_img} isFavorite={Boolean(favorite)} />
                     })
                 }
             </div>

--- a/src/components/FeedIndex.tsx
+++ b/src/components/FeedIndex.tsx
@@ -45,13 +45,13 @@ const FeedIndex: React.FC<FeedIndexProps> = ({ userId }) => {
       <div className="w-full px-4 pb-24">
         <h1>ff</h1>
         {events &&
-          events.map(({ id, brochure_img, favorite, notes, title, likedIds }: Event) => {
+          events.map(({ id, brochure_img, favorite, notes, title, likedUserIds }: Event) => {
             return (
               <EventCard
                 key={id}
                 userId={userId}
                 eventId={id}
-                likes={likedIds.length}
+                likes={likedUserIds!.length}
                 eventName={title}
                 eventDescription={notes?.join('')}
                 thumbnail={brochure_img}

--- a/src/components/FeedIndex.tsx
+++ b/src/components/FeedIndex.tsx
@@ -1,6 +1,9 @@
 import { AiOutlineHeart, AiOutlineSmile } from 'react-icons/ai'
 import { MdFlipCameraAndroid } from 'react-icons/md'
 
+import useEvents from '@/hooks/useEvents';
+import { useSession } from 'next-auth/react';
+
 import BottomNav from '@/components/BottomNav';
 import EventCard from '@/components/EventCard';
 
@@ -26,11 +29,17 @@ const navList = [
 ]
 
 export function FeedIndex() {
+    const { data: session } = useSession()
+    const { data: events } = useEvents(session?.user.id);
 
     return (
         <>
-            <div className='px-4'>
-                <EventCard eventName="Event Name" eventDescription="A week of cool lights/lantern exhibits in Taipei" isFavorite />
+            <div className='w-full px-4'>
+                {
+                    events && events.map(({ brochure_img, favorite, note, title }) => {
+                        return <EventCard eventName={title} eventDescription={note} thumbnail={brochure_img} isFavorite={favorite} />
+                    })
+                }
             </div>
             <BottomNav tabs={navList} />
         </>

--- a/src/components/FeedIndex.tsx
+++ b/src/components/FeedIndex.tsx
@@ -1,0 +1,35 @@
+import { AiOutlineHeart, AiOutlineSmile } from 'react-icons/ai'
+import { MdFlipCameraAndroid } from 'react-icons/md'
+
+import BottomNav from '@/components/BottomNav';
+
+const navList = [
+    {
+        name: 'Favorite',
+        href: '/',
+        tabName: 'Favorite',
+        icon: <AiOutlineHeart size={24} />,
+    },
+    {
+        name: 'Capture',
+        href: '/capture',
+        tabName: 'Capture',
+        icon: <MdFlipCameraAndroid size={24} />,
+    },
+    {
+        name: 'Profile',
+        href: '/profile',
+        tabName: 'Profile',
+        icon: <AiOutlineSmile size={24} />,
+    },
+]
+
+export function FeedIndex() {
+
+    return (
+        <>
+            <h1>hello</h1>
+            <BottomNav tabs={navList} />
+        </>
+    )
+}

--- a/src/components/FeedIndex.tsx
+++ b/src/components/FeedIndex.tsx
@@ -2,6 +2,7 @@ import { AiOutlineHeart, AiOutlineSmile } from 'react-icons/ai'
 import { MdFlipCameraAndroid } from 'react-icons/md'
 
 import BottomNav from '@/components/BottomNav';
+import EventCard from '@/components/EventCard';
 
 const navList = [
     {
@@ -28,7 +29,9 @@ export function FeedIndex() {
 
     return (
         <>
-            <h1>hello</h1>
+            <div className='px-4'>
+                <EventCard eventName="Event Name" eventDescription="A week of cool lights/lantern exhibits in Taipei" isFavorite />
+            </div>
             <BottomNav tabs={navList} />
         </>
     )

--- a/src/hooks/useLike.ts
+++ b/src/hooks/useLike.ts
@@ -1,0 +1,60 @@
+import axios from 'axios'
+import { useCallback, useMemo } from 'react'
+
+import useCurrentUser from './useCurrentUser'
+import useEvent from './useEvent'
+import useEvents from './useEvents'
+import { useToast } from './useToast'
+import { useRouter } from 'next/router'
+
+const useLike = ({ eventId, userId }: { eventId: string; userId?: string }) => {
+  const { data: currentUser } = useCurrentUser()
+  const {data: fetchedEvent, mutate: mutateFetchedEvent} = useEvent(eventId)
+  const { mutate: mutateFetchedEvents } = useEvents(userId)
+
+  const { toast } = useToast()
+  const router = useRouter()
+
+  const hasLiked = useMemo(() => {
+    const list = fetchedEvent?.likedIds || []
+
+    return list.includes(currentUser?.id)
+  }, [fetchedEvent, currentUser])
+
+  const toggleLike = useCallback(async () => {
+    if (!currentUser) {
+      return router.push('/signup')
+    }
+
+    try {
+      let request
+
+      if (hasLiked) {
+        request = () => axios.delete('/api/like', { data: { eventId } })
+      } else {
+        request = () => axios.post('/api/like', { eventId })
+      }
+
+      await request()
+      mutateFetchedEvent()
+      mutateFetchedEvents()
+
+      toast({
+        variant: 'success',
+        description: 'Event Liked',
+      })
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        description: 'Something went wrong',
+      })
+    }
+  }, [currentUser, hasLiked, eventId, mutateFetchedEvents, mutateFetchedEvent])
+
+  return {
+    hasLiked,
+    toggleLike,
+  }
+}
+
+export default useLike

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,71 @@
+export interface Account {
+  id: string;
+  userId: string;
+  type: string;
+  provider: string;
+  providerAccountId: string;
+  refresh_token?: string;
+  access_token?: string;
+  expires_at?: number;
+  token_type?: string;
+  scope?: string;
+  id_token?: string;
+  session_state?: string;
+  user: User;
+}
+
+export interface Session {
+  id: string;
+  sessionToken: string;
+  userId: string;
+  expires: Date;
+  user: User;
+}
+
+export interface User {
+  id: string;
+  name?: string;
+  email?: string;
+  emailVerified?: Date;
+  image?: string;
+  hashedPassword?: string;
+  sharedEventIds?: string[];
+  accounts?: Account[];
+  sessions?: Session[];
+  initiatedEvents?: Event[];
+  sharedEvents?: Event[];
+  notes?: Note[];
+}
+
+export interface Event {
+  id: string;
+  title: string;
+  createdAt: Date;
+  updatedAt: Date;
+  brochure_img?: string;
+  isPublic?: boolean;
+  favorite?: boolean;
+  tag?: string;
+  date?: Date;
+  sharedUserIds?: string[];
+  sharedUsers?: User[];
+  userId: string;
+  user: User;
+  notes?: Note[];
+}
+
+export interface Note {
+  id: string;
+  content: string;
+  eventId: string;
+  event: Event;
+  userId: string;
+  user: User;
+}
+
+export interface VerificationToken {
+  id: string;
+  identifier: string;
+  token: string;
+  expires: Date;
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -35,6 +35,8 @@ export interface User {
   initiatedEvents?: Event[];
   sharedEvents?: Event[];
   notes?: Note[];
+  likedEventIds?: string[];
+  likedEvents?: Event[];
 }
 
 export interface Event {
@@ -52,7 +54,8 @@ export interface Event {
   userId: string;
   user: User;
   notes?: Note[];
-  likedIds: string[];
+  likedUserIds?: string[];
+  likedUsers?: User[];
 }
 
 export interface Note {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -30,13 +30,13 @@ export interface User {
   image?: string;
   hashedPassword?: string;
   sharedEventIds?: string[];
+  likedEventIds?: string[];
   accounts?: Account[];
   sessions?: Session[];
   initiatedEvents?: Event[];
   sharedEvents?: Event[];
-  notes?: Note[];
-  likedEventIds?: string[];
   likedEvents?: Event[];
+  notes?: Note[];
 }
 
 export interface Event {
@@ -49,13 +49,13 @@ export interface Event {
   favorite?: boolean;
   tag?: string;
   date?: Date;
+  likedUserIds?: string[];
+  linkedUsers?: User[];
   sharedUserIds?: string[];
   sharedUsers?: User[];
   userId: string;
   user: User;
   notes?: Note[];
-  likedUserIds?: string[];
-  likedUsers?: User[];
 }
 
 export interface Note {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -52,6 +52,7 @@ export interface Event {
   userId: string;
   user: User;
   notes?: Note[];
+  likedIds: string[];
 }
 
 export interface Note {

--- a/src/lib/serverAuth.ts
+++ b/src/lib/serverAuth.ts
@@ -1,9 +1,9 @@
-import { NextApiRequest } from 'next'
+import { NextApiRequest, NextApiResponse } from 'next'
 import { getSession } from 'next-auth/react'
 
 import db from '@/lib/prismadb'
 
-const serverAuth = async (req: NextApiRequest) => {
+const serverAuth = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getSession({ req })
 
   if (!session?.user?.email) {

--- a/src/pages/api/like.ts
+++ b/src/pages/api/like.ts
@@ -30,7 +30,7 @@ export default async function handler(
       throw new Error('Invalid ID')
     }
 
-    let updatedLikedIds = [...(event.likedIds || [])]
+    let updatedLikedIds = [...(event.likedUserIds || [])]
 
     if (req.method === 'POST') {
       updatedLikedIds.push(currentUser.id)
@@ -47,7 +47,7 @@ export default async function handler(
         id: eventId,
       },
       data: {
-        likedIds: updatedLikedIds,
+        likedUserIds: updatedLikedIds,
       },
     })
 

--- a/src/pages/api/like.ts
+++ b/src/pages/api/like.ts
@@ -1,0 +1,59 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import db from '@/lib/prismadb'
+import serverAuth from '@/lib/serverAuth'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'POST' && req.method !== 'DELETE') {
+    return res.status(405).end()
+  }
+
+  try {
+    const { eventId } = req.body
+
+    const { currentUser } = await serverAuth(req, res)
+
+    if (!eventId || typeof eventId !== 'string') {
+      throw new Error('Invalid ID')
+    }
+
+    const event = await db.event.findUnique({
+      where: {
+        id: eventId,
+      },
+    })
+
+    if (!event) {
+      throw new Error('Invalid ID')
+    }
+
+    let updatedLikedIds = [...(event.likedIds || [])]
+
+    if (req.method === 'POST') {
+      updatedLikedIds.push(currentUser.id)
+    }
+
+    if (req.method === 'DELETE') {
+      updatedLikedIds = updatedLikedIds.filter(
+        (likedId) => likedId !== currentUser?.id,
+      )
+    }
+
+    const updatedEvent = await db.event.update({
+      where: {
+        id: eventId,
+      },
+      data: {
+        likedIds: updatedLikedIds,
+      },
+    })
+
+    return res.status(200).json(updatedEvent)
+  } catch (error) {
+    console.log(error)
+    return res.status(400).end()
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { EventModal } from '@/components/EventModal'
 import TopNav from '@/components/TopNav'
+import { FeedIndex } from '@/components/FeedIndex'
 import { Button, buttonVariants } from '@/components/ui/Button'
 import useCurrentUser from '@/hooks/useCurrentUser'
 import useEvents from '@/hooks/useEvents'
@@ -50,6 +51,7 @@ const Home: NextPage = () => {
       <div className="flex text-center space-y-4 min-h-screen flex-col bg-[url('/noise.png')] items-center justify-center py-2 dark:bg-[#18191b] dark:text-white">
         <TopNav />
         <EventModal />
+        <FeedIndex />
       </div>
     )
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,6 @@ import TopNav from '@/components/TopNav'
 import { FeedIndex } from '@/components/FeedIndex'
 import { Button, buttonVariants } from '@/components/ui/Button'
 import useCurrentUser from '@/hooks/useCurrentUser'
-import useEvents from '@/hooks/useEvents'
 import { useToast } from '@/hooks/useToast'
 import axios from 'axios'
 import type { NextPage } from 'next'
@@ -14,10 +13,6 @@ import { useCallback, useState } from 'react'
 const Home: NextPage = () => {
   const { data: session, status } = useSession()
   const { data: currentUser } = useCurrentUser()
-
-  const { data: events = [] } = useEvents()
-
-  console.log('events :::: ', events)
 
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [name, setName] = useState<string>(currentUser?.name)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,7 @@ const Home: NextPage = () => {
 
   if (status === 'authenticated') {
     return (
-      <div className="flex text-center space-y-4 min-h-screen flex-col bg-[url('/noise.png')] items-center justify-center py-2 dark:bg-[#18191b] dark:text-white">
+      <div className="flex text-center space-y-4 min-h-screen flex-col items-center justify-center py-2 dark:bg-[#18191b] dark:text-white bg-[#EFF7FF]">
         <TopNav />
         <EventModal />
         <FeedIndex />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { EventModal } from '@/components/EventModal'
+import FeedIndex from '@/components/FeedIndex'
 import TopNav from '@/components/TopNav'
-import { FeedIndex } from '@/components/FeedIndex'
 import { Button, buttonVariants } from '@/components/ui/Button'
 import useCurrentUser from '@/hooks/useCurrentUser'
 import { useToast } from '@/hooks/useToast'
@@ -45,8 +45,8 @@ const Home: NextPage = () => {
     return (
       <div className="flex text-center space-y-4 min-h-screen flex-col items-center justify-center py-2 dark:bg-[#18191b] dark:text-white bg-[#EFF7FF]">
         <TopNav />
-        <EventModal />
-        <FeedIndex />
+        {/* <EventModal /> */}
+        {currentUser && <FeedIndex userId={currentUser.id} />}
       </div>
     )
   }


### PR DESCRIPTION
<img width="306" alt="截圖 2023-04-09 下午12 56 44" src="https://user-images.githubusercontent.com/35912741/230755158-fdd7bda2-4585-4729-b231-2db1f00ed010.png">

1. I skiped the hover card for now, since mobile devices generally don't have a hover action.
2. I'm not sure if there's a `refetch` method available after `favorite` toggle, so for the moment, l used `window.location.reload()` to update the status immediately.
3. Use Pal.js to generate types according to the schema.prisma file, which can then be used by the client side.



